### PR TITLE
Use np.frombuffer instead of np.fromstring

### DIFF
--- a/gnsstools/io.py
+++ b/gnsstools/io.py
@@ -4,7 +4,7 @@ def get_samples_complex(fp,n):
   z = fp.read(2*n)
   if len(z)!=2*n:
     return None
-  s = np.fromstring(z,dtype='int8')
+  s = np.frombuffer(z,dtype='int8')
   s.shape = (n,2)
   x = np.empty(n,dtype='c8')
   x.real = s[:,0]


### PR DESCRIPTION
Numpy 2.3.1 errors out saying that the binary mode of fromstring is removed and that frombuffer should be used instead.